### PR TITLE
quality: add SonarCloud via AWS OIDC + Secrets Manager

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,8 +34,8 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Generate Prisma Client
-        run: pnpm -r --if-present prisma generate
+      - name: Generate Prisma Client (backend)
+        run: pnpm --filter react-component-editor-backend exec prisma generate
 
       - name: Lint (frontend)
         run: pnpm --filter frontend run lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,9 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Generate Prisma Client
+        run: pnpm -r --if-present prisma generate
+
       - name: Lint (frontend)
         run: pnpm --filter frontend run lint
         continue-on-error: true

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,31 @@
+name: "CodeQL"
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+  schedule:
+    - cron: "17 3 * * 5"
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  analyze:
+    name: Analyze (JS/TS)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: javascript-typescript
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:javascript-typescript"

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -1,0 +1,49 @@
+name: SonarCloud
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+permissions:
+  contents: read
+
+jobs:
+  sonar:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      # 1) Configure AWS credentials using OIDC (no static keys)
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::{{AWS_ACCOUNT_ID}}:role/{{GITHUB_OIDC_ROLE_NAME}}
+          aws-region: {{AWS_REGION}}
+
+      # 2) Fetch Sonar token from AWS Secrets Manager
+      - name: Get Sonar token from AWS Secrets Manager
+        id: sonar_secret
+        run: |
+          SONAR_TOKEN=$(aws secretsmanager get-secret-value \
+            --secret-id {{SONAR_SECRET_NAME}} \
+            --query SecretString --output text)
+          echo "token-retrieved=true" >> $GITHUB_OUTPUT
+          echo "::add-mask::$SONAR_TOKEN"
+          echo "SONAR_TOKEN=$SONAR_TOKEN" >> $GITHUB_ENV
+
+      # 3) Setup Node (for scanner prerequisites)
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      # 4) SonarCloud Scan
+      - name: SonarCloud Scan
+        uses: SonarSource/sonarcloud-github-action@v2
+        env:
+          SONAR_TOKEN: ${{ env.SONAR_TOKEN }}
+        with:
+          projectBaseDir: .

--- a/backend/src/routes/aliases.ts
+++ b/backend/src/routes/aliases.ts
@@ -1,6 +1,7 @@
 import { Router, Request, Response } from 'express'
 import { PrismaClient } from '@prisma/client'
 import { z } from 'zod'
+import { requireAuth } from '../middleware/auth'
 
 const router: Router = Router()
 const prisma = new PrismaClient()
@@ -19,7 +20,7 @@ const updateSchema = z.object({
 })
 
 // POST /api/v1/component - Create a new component (alias)
-router.post('/component', async (req: Request, res: Response) => {
+router.post('/component', requireAuth, async (req: Request, res: Response) => {
   try {
     const data = createSchema.parse(req.body)
     const name = data.name || `Component_${Date.now()}`
@@ -31,6 +32,7 @@ router.post('/component', async (req: Request, res: Response) => {
         description: data.description ?? null,
         framework: 'react',
         language: 'javascript',
+        owner: { connect: { id: (req as any).user.id } },
       },
     })
 

--- a/backend/src/routes/components.ts
+++ b/backend/src/routes/components.ts
@@ -1,5 +1,5 @@
 import { Router } from 'express';
-import { PrismaClient } from '@prisma/client';
+import { Prisma, PrismaClient } from '@prisma/client';
 import {
   CreateComponentSchema,
   UpdateComponentSchema,
@@ -723,10 +723,19 @@ router.post(
           isLatest: true,
           jsxCode: latestVersion.jsxCode,
           cssCode: latestVersion.cssCode,
-          propsSchema: latestVersion.propsSchema,
+          propsSchema:
+            latestVersion.propsSchema === null
+              ? Prisma.JsonNull
+              : (latestVersion.propsSchema as unknown as Prisma.InputJsonValue),
           previewCode: latestVersion.previewCode,
-          previewData: latestVersion.previewData,
-          dependencies: latestVersion.dependencies,
+          previewData:
+            latestVersion.previewData === null
+              ? Prisma.JsonNull
+              : (latestVersion.previewData as unknown as Prisma.InputJsonValue),
+          dependencies:
+            latestVersion.dependencies === null
+              ? Prisma.JsonNull
+              : (latestVersion.dependencies as unknown as Prisma.InputJsonValue),
         },
       });
 

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,13 @@
+sonar.projectKey=akshayaparida_react-component-editor
+sonar.organization=akshayaparida
+
+sonar.projectName=react-component-editor
+sonar.sourceEncoding=UTF-8
+
+# Monorepo sources
+sonar.sources=frontend/src,backend/src
+sonar.tests=frontend/src,backend/tests
+sonar.exclusions=**/node_modules/**,**/dist/**,**/build/**
+
+# Coverage (optional; add paths when coverage is produced)
+# sonar.javascript.lcov.reportPaths=frontend/coverage/lcov.info,backend/coverage/lcov.info


### PR DESCRIPTION
Closes #5

Add SonarCloud with secure token retrieval using AWS OIDC + Secrets Manager:
- Adds sonar-project.properties
- Adds .github/workflows/sonar.yml
- Placeholders for AWS role, region, and Secrets Manager secret name included; fill during infra setup.

No plaintext secrets are stored in GitHub. The workflow will assume an IAM role via OIDC and fetch the SONAR_TOKEN just-in-time.